### PR TITLE
Feat/3 elemental states

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/PCH.cpp
     src/Plugin.cpp
     src/RemoveDrains.cpp
+    src/ElementalStates.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,11 @@ add_commonlibsse_plugin(${PROJECT_NAME}
   SOURCES
     src/PCH.cpp
     src/Plugin.cpp
+    src/RemoveDrains.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
-target_precompile_headers(${PROJECT_NAME} PRIVATE src/PCH.h)
+target_precompile_headers(${PROJECT_NAME} PRIVATE src/PCH.h src/ElementalStates.h src/RemoveDrains.h)
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "SMSODestruction")
 
 if(DEFINED OUTPUT_FOLDER)

--- a/README.md
+++ b/README.md
@@ -5,45 +5,58 @@
 ## Features
 
 ### 1. Elemental Gauges
+
 Every Destruction spell (fire, frost, shock) builds a corresponding gauge (*FireGauge*, *FrostGauge*, *ShockGauge*) on enemies when hit. Gauges track elemental exposure, enabling powerful effects and reactions when filled to 100 units.
 
 ### 2. Elemental States
+
 Environmental and equipment-based states alter how enemies interact with magic:
+
 - **Wet**: Triggered by rain or water effects. Reduces fire damage and *FireGauge* buildup, but boosts shock damage and *frostGauge*.
 - **Rubber**: From crafted rubber armor. Reduces shock damage and *ShockGauge* buildup, but ncreases the buildup rate of FireGauge and FrostGauge.
 - **Fur/Fat**: From crafted fur armor or enemies like trolls. Enhances frost resistance and *FrostGauge* buildup, but increases fire damage taken and speeds up ShockGauge buildup
 
 ### 3. Maximum Gauge Effects
+
 When a gauge reaches 100 units, a unique effect triggers:
+
 - **Incineration (Fire)**: A damage-over-time (DoT) effect burns the target.
 - **Deep Freeze (Frost)**: Freezes the target for 3 seconds, immobilizing them with a lingering slow effect.
 - **Overcharge (Shock)**: Cause small continuous electric shocks that stagger the enemy for 0.3 seconds every 1.3 seconds. Enemies with the 'electrified' effect shock nearby enemies also affected by electricity.
 
 ### 4. Elemental Reactions
+
 Combining elements triggers powerful reactions by consuming one gauge to amplify another:
 
 ### 5. Removal of Vanilla Drains
+
 Vanilla magicka and stamina drains from shock and frost spells are removed, replaced by the gauge system for a cohesive experience.
 
 ### 6. Reworked Spells (39 New Spells)
+
 The Destruction school is revamped with 39 spells (11 fire, 11 frost, 11 shock), from Novice to Master:
 
 ### 7. Reworked Perks
+
 The Destruction perk tree is overhauled:
 
 ### 8. Power-Ups for Low-Level Spells
+
 Novice to Adept spells scale with Destruction skill.
 
 ### 9. Cooldowns for Balance
+
 Spells have cooldowns.
 
 ### 10. Long-Cast Animations and NPC Collaboration
+
 Higher-ranked spells have longer animations. Spells will continuously drain mana during the animation until their cost is met. It is possible for one (or more) NPC with the same spell to cast simultaneously, jointly consuming mana until the total required for activating the spell is reached. If this is done, only one spell will be cast, but the casting time can be drastically reduced. The initial mana points are consumed more rapidly, but subsequent points are consumed more slowly.
 
 ## Contributing
 
 Want to contribute to *SMSOD*? We welcome bug fixes, feature suggestions, and code contributions!
-1. Fork the repository on [GitHub](https://github.com/yourusername/smsod).
+
+1. Fork the repository on [GitHub](https://github.com/IgorAlanAlbuquerque/SMSO---Destruction/tree/main).
 2. Create a branch for your changes (`git checkout -b feature/your-feature`).
 3. Commit your changes with clear messages (`git commit -m "Add feature X"`).
 4. Push to your fork (`git push origin feature/your-feature`).

--- a/src/ElementalStates.cpp
+++ b/src/ElementalStates.cpp
@@ -1,0 +1,96 @@
+#include "ElementalStates.h"
+
+#include <unordered_map>
+
+namespace ElementalStates {
+    namespace Flags {
+        using Bits = std::uint8_t;
+
+        static std::unordered_map<RE::FormID, Bits> gBits;
+
+        constexpr Bits bit(Flag f) { return static_cast<Bits>(1u << static_cast<unsigned>(f)); }
+
+        constexpr std::uint32_t kUniqueID = 'ELMS';
+        constexpr std::uint32_t kRecordID = 'FLGS';
+        constexpr std::uint32_t kVersion = 1;
+    }
+
+    void Set(const RE::Actor* a, Flag f, bool value) {
+        if (!a) return;
+        auto& b = Flags::gBits[a->GetFormID()];
+        const Flags::Bits m = Flags::bit(f);
+        if (value)
+            b |= m;
+        else
+            b &= ~m;
+    }
+
+    bool Get(const RE::Actor* a, Flag f) {
+        if (!a) return false;
+        auto it = Flags::gBits.find(a->GetFormID());
+        if (it == Flags::gBits.end()) return false;
+        return (it->second & Flags::bit(f)) != 0;
+    }
+
+    void Clear(const RE::Actor* a) {
+        if (!a) return;
+        Flags::gBits.erase(a->GetFormID());
+    }
+
+    void ClearAll() { Flags::gBits.clear(); }
+
+    // ----- Callbacks SKSE -----
+    static void OnSave(SKSE::SerializationInterface* ser) {
+        if (!ser) return;
+        if (!ser->OpenRecord(Flags::kRecordID, Flags::kVersion)) {
+            return;
+        }
+        const std::uint32_t count = static_cast<std::uint32_t>(Flags::gBits.size());
+        ser->WriteRecordData(&count, sizeof(count));
+        for (const auto& [formID, bits] : Flags::gBits) {
+            ser->WriteRecordData(&formID, sizeof(formID));
+            ser->WriteRecordData(&bits, sizeof(bits));
+        }
+    }
+
+    static void OnLoad(SKSE::SerializationInterface* ser) {
+        if (!ser) return;
+
+        std::uint32_t type{}, version{}, length{};
+        while (ser->GetNextRecordInfo(type, version, length)) {
+            if (type != Flags::kRecordID || version != Flags::kVersion) {
+                // Outros records do plugin (se existirem) ou versões antigas
+                continue;
+            }
+
+            std::uint32_t count = 0;
+            if (!ser->ReadRecordData(&count, sizeof(count))) {
+                continue;
+            }
+
+            Flags::gBits.clear();
+            for (std::uint32_t i = 0; i < count; ++i) {
+                RE::FormID oldID{};
+                Flags::Bits bits{};
+                if (!ser->ReadRecordData(&oldID, sizeof(oldID))) break;
+                if (!ser->ReadRecordData(&bits, sizeof(bits))) break;
+
+                RE::FormID newID{};
+                if (!ser->ResolveFormID(oldID, newID)) {
+                    continue;
+                }
+                Flags::gBits[newID] = bits;
+            }
+        }
+    }
+
+    static void OnRevert(SKSE::SerializationInterface*) { Flags::gBits.clear(); }
+
+    void RegisterSerialization() {
+        auto* ser = SKSE::GetSerializationInterface();
+        ser->SetUniqueID(Flags::kUniqueID);
+        ser->SetSaveCallback(OnSave);
+        ser->SetLoadCallback(OnLoad);
+        ser->SetRevertCallback(OnRevert);
+    }
+}

--- a/src/ElementalStates.cpp
+++ b/src/ElementalStates.cpp
@@ -1,24 +1,37 @@
 #include "ElementalStates.h"
 
-#include <unordered_map>
+#if !defined(__cpp_lib_to_underlying) || (__cpp_lib_to_underlying < 202102L)
+template <class Enum>
+constexpr std::underlying_type_t<Enum> to_underlying(Enum e) noexcept {
+    return static_cast<std::underlying_type_t<Enum>>(e);
+}
+#else
+using std::to_underlying;
+#endif
 
 namespace ElementalStates {
     namespace Flags {
-        using Bits = std::uint8_t;
+        using Bits = std::byte;
+        using Map = std::unordered_map<RE::FormID, Bits>;
 
-        static std::unordered_map<RE::FormID, Bits> gBits;
+        static Map& state() noexcept {
+            static Map m;  // NOSONAR: estado centralizado com duração estática, serializado via SKSE
+            return m;
+        }
 
-        constexpr Bits bit(Flag f) { return static_cast<Bits>(1u << static_cast<unsigned>(f)); }
+        [[nodiscard]] constexpr std::byte bit(Flag f) noexcept {
+            return std::byte{1} << static_cast<int>(to_underlying(f));
+        }
 
-        constexpr std::uint32_t kUniqueID = 'ELMS';
-        constexpr std::uint32_t kRecordID = 'FLGS';
-        constexpr std::uint32_t kVersion = 1;
+        inline constexpr std::uint32_t kUniqueID = FOURCC('E', 'L', 'M', 'S');
+        inline constexpr std::uint32_t kRecordID = FOURCC('F', 'L', 'G', 'S');
+        inline constexpr std::uint32_t kVersion = 1;
     }
 
     void Set(const RE::Actor* a, Flag f, bool value) {
         if (!a) return;
-        auto& b = Flags::gBits[a->GetFormID()];
-        const Flags::Bits m = Flags::bit(f);
+        auto& b = Flags::state()[a->GetFormID()];
+        const auto m = Flags::bit(f);
         if (value)
             b |= m;
         else
@@ -27,64 +40,64 @@ namespace ElementalStates {
 
     bool Get(const RE::Actor* a, Flag f) {
         if (!a) return false;
-        auto it = Flags::gBits.find(a->GetFormID());
-        if (it == Flags::gBits.end()) return false;
-        return (it->second & Flags::bit(f)) != 0;
+        const auto& map = Flags::state();
+        const auto it = map.find(a->GetFormID());
+        if (it == map.end()) return false;
+        return (it->second & Flags::bit(f)) != std::byte{0};
     }
 
     void Clear(const RE::Actor* a) {
         if (!a) return;
-        Flags::gBits.erase(a->GetFormID());
+        Flags::state().erase(a->GetFormID());
     }
 
-    void ClearAll() { Flags::gBits.clear(); }
+    void ClearAll() { Flags::state().clear(); }
 
     // ----- Callbacks SKSE -----
     static void OnSave(SKSE::SerializationInterface* ser) {
         if (!ser) return;
-        if (!ser->OpenRecord(Flags::kRecordID, Flags::kVersion)) {
-            return;
-        }
-        const std::uint32_t count = static_cast<std::uint32_t>(Flags::gBits.size());
+        if (!ser->OpenRecord(Flags::kRecordID, Flags::kVersion)) return;
+
+        const auto& map = Flags::state();
+        const auto count = static_cast<std::uint32_t>(map.size());
         ser->WriteRecordData(&count, sizeof(count));
-        for (const auto& [formID, bits] : Flags::gBits) {
+
+        for (const auto& [formID, bits] : map) {
+            std::uint8_t raw = std::to_integer<std::uint8_t>(bits);
             ser->WriteRecordData(&formID, sizeof(formID));
-            ser->WriteRecordData(&bits, sizeof(bits));
+            ser->WriteRecordData(&raw, sizeof(raw));
         }
     }
 
     static void OnLoad(SKSE::SerializationInterface* ser) {
         if (!ser) return;
 
-        std::uint32_t type{}, version{}, length{};
+        std::uint32_t type{};
+        std::uint32_t version{};
+        std::uint32_t length{};
         while (ser->GetNextRecordInfo(type, version, length)) {
-            if (type != Flags::kRecordID || version != Flags::kVersion) {
-                // Outros records do plugin (se existirem) ou versões antigas
-                continue;
-            }
+            if (type != Flags::kRecordID || version != Flags::kVersion) continue;
 
             std::uint32_t count = 0;
-            if (!ser->ReadRecordData(&count, sizeof(count))) {
-                continue;
-            }
+            if (!ser->ReadRecordData(&count, sizeof(count))) continue;
 
-            Flags::gBits.clear();
+            auto& map = Flags::state();
+            map.clear();
+
             for (std::uint32_t i = 0; i < count; ++i) {
                 RE::FormID oldID{};
-                Flags::Bits bits{};
-                if (!ser->ReadRecordData(&oldID, sizeof(oldID))) break;
-                if (!ser->ReadRecordData(&bits, sizeof(bits))) break;
+                std::uint8_t raw{};
+                if (!ser->ReadRecordData(&oldID, sizeof(oldID)) || !ser->ReadRecordData(&raw, sizeof(raw))) break;
 
                 RE::FormID newID{};
-                if (!ser->ResolveFormID(oldID, newID)) {
-                    continue;
-                }
-                Flags::gBits[newID] = bits;
+                if (!ser->ResolveFormID(oldID, newID)) continue;
+
+                map[newID] = std::byte{raw};
             }
         }
     }
 
-    static void OnRevert(SKSE::SerializationInterface*) { Flags::gBits.clear(); }
+    static void OnRevert(SKSE::SerializationInterface*) { Flags::state().clear(); }
 
     void RegisterSerialization() {
         auto* ser = SKSE::GetSerializationInterface();
@@ -92,5 +105,44 @@ namespace ElementalStates {
         ser->SetSaveCallback(OnSave);
         ser->SetLoadCallback(OnLoad);
         ser->SetRevertCallback(OnRevert);
+    }
+}
+
+namespace ElementalStatesTest {
+    using enum ElementalStates::Flag;
+
+    void RunOnce() {
+        const RE::PlayerCharacter* pc = RE::PlayerCharacter::GetSingleton();
+        if (!pc) {
+            spdlog::error("[TEST] PlayerCharacter não encontrado");
+            return;
+        }
+
+        // snapshot inicial
+        auto wet = ElementalStates::Get(pc, Wet);
+        auto rubber = ElementalStates::Get(pc, Rubber);
+        auto fur = ElementalStates::Get(pc, Fur);
+        auto fat = ElementalStates::Get(pc, Fat);
+        spdlog::info("[TEST] inicial: Wet={} Rubber={} Fur={} Fat={}", wet, rubber, fur, fat);
+
+        // liga duas flags
+        ElementalStates::Set(pc, Wet, true);
+        ElementalStates::Set(pc, Rubber, true);
+
+        spdlog::info("[TEST] depois de set: Wet={} Rubber={} Fur={} Fat={}", ElementalStates::Get(pc, Wet),
+                     ElementalStates::Get(pc, Rubber), ElementalStates::Get(pc, Fur), ElementalStates::Get(pc, Fat));
+
+        // alterna
+        ElementalStates::Set(pc, Wet, false);
+        ElementalStates::Set(pc, Rubber, false);
+        ElementalStates::Set(pc, Fur, true);
+        ElementalStates::Set(pc, Fat, true);
+
+        spdlog::info("[TEST] depois do toggle: Wet={} Rubber={} Fur={} Fat={}", ElementalStates::Get(pc, Wet),
+                     ElementalStates::Get(pc, Rubber), ElementalStates::Get(pc, Fur), ElementalStates::Get(pc, Fat));
+        ElementalStates::Set(pc, Wet, wet);
+        ElementalStates::Set(pc, Rubber, rubber);
+        ElementalStates::Set(pc, Fur, fur);
+        ElementalStates::Set(pc, Fat, fat);
     }
 }

--- a/src/ElementalStates.h
+++ b/src/ElementalStates.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "RE/Skyrim.h"
+
+namespace ElemStates {
+    enum class ElementalState { Wet, Rubber, Fur, Fat };
+
+    class ExtraElementalState : public RE::BSExtraData {
+    public:
+        inline static constexpr auto EXTRADATA_TYPE = static_cast<RE::ExtraDataType>(0x8000);
+
+        bool wet = false;
+        bool rubber = false;
+        bool fur = false;
+        bool fat = false;
+
+        static ExtraElementalState* GetOrCreate(RE::Actor* actor) {
+            if (!actor) return nullptr;
+
+            auto xList = actor->extraList;
+            auto existing = static_cast<ExtraElementalState*>(xList.GetByType(EXTRADATA_TYPE));
+            if (existing) return existing;
+
+            auto* extra = new ExtraElementalState();
+            xList.Add(extra);
+            return extra;
+        }
+
+        bool Get(ElementalState state) {
+            switch (state) {
+                case ElementalState::Wet:
+                    return wet;
+                case ElementalState::Rubber:
+                    return rubber;
+                case ElementalState::Fur:
+                    return fur;
+                case ElementalState::Fat:
+                    return fat;
+                default:
+                    return false;
+            }
+        }
+
+        void Set(ElementalState state, bool value) {
+            switch (state) {
+                case ElementalState::Wet:
+                    wet = value;
+                    break;
+                case ElementalState::Rubber:
+                    rubber = value;
+                    break;
+                case ElementalState::Fur:
+                    fur = value;
+                    break;
+                case ElementalState::Fat:
+                    fat = value;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        virtual RE::ExtraDataType GetType() const override;
+    };
+
+    inline bool GetState(RE::Actor* actor, ElementalState state) {
+        if (auto* data = ExtraElementalState::GetOrCreate(actor)) {
+            return data->Get(state);
+        }
+        return false;
+    }
+
+    inline void SetState(RE::Actor* actor, ElementalState state, bool value) {
+        if (auto* data = ExtraElementalState::GetOrCreate(actor)) {
+            data->Set(state, value);
+        }
+    }
+}

--- a/src/ElementalStates.h
+++ b/src/ElementalStates.h
@@ -1,78 +1,18 @@
 #pragma once
 
+#include <cstdint>
+
 #include "RE/Skyrim.h"
+#include "SKSE/SKSE.h"
 
-namespace ElemStates {
-    enum class ElementalState { Wet, Rubber, Fur, Fat };
+namespace ElementalStates {
+    enum class Flag : std::uint8_t { Wet = 0, Rubber = 1, Fur = 2, Fat = 3 };
 
-    class ExtraElementalState : public RE::BSExtraData {
-    public:
-        inline static constexpr auto EXTRADATA_TYPE = static_cast<RE::ExtraDataType>(0x8000);
+    void RegisterSerialization();
 
-        bool wet = false;
-        bool rubber = false;
-        bool fur = false;
-        bool fat = false;
+    void Set(RE::Actor* a, Flag f, bool value);
+    bool Get(RE::Actor* a, Flag f);
 
-        static ExtraElementalState* GetOrCreate(RE::Actor* actor) {
-            if (!actor) return nullptr;
-
-            auto xList = actor->extraList;
-            auto existing = static_cast<ExtraElementalState*>(xList.GetByType(EXTRADATA_TYPE));
-            if (existing) return existing;
-
-            auto* extra = new ExtraElementalState();
-            xList.Add(extra);
-            return extra;
-        }
-
-        bool Get(ElementalState state) {
-            switch (state) {
-                case ElementalState::Wet:
-                    return wet;
-                case ElementalState::Rubber:
-                    return rubber;
-                case ElementalState::Fur:
-                    return fur;
-                case ElementalState::Fat:
-                    return fat;
-                default:
-                    return false;
-            }
-        }
-
-        void Set(ElementalState state, bool value) {
-            switch (state) {
-                case ElementalState::Wet:
-                    wet = value;
-                    break;
-                case ElementalState::Rubber:
-                    rubber = value;
-                    break;
-                case ElementalState::Fur:
-                    fur = value;
-                    break;
-                case ElementalState::Fat:
-                    fat = value;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        virtual RE::ExtraDataType GetType() const override;
-    };
-
-    inline bool GetState(RE::Actor* actor, ElementalState state) {
-        if (auto* data = ExtraElementalState::GetOrCreate(actor)) {
-            return data->Get(state);
-        }
-        return false;
-    }
-
-    inline void SetState(RE::Actor* actor, ElementalState state, bool value) {
-        if (auto* data = ExtraElementalState::GetOrCreate(actor)) {
-            data->Set(state, value);
-        }
-    }
+    void Clear(RE::Actor* a);
+    void ClearAll();
 }

--- a/src/ElementalStates.h
+++ b/src/ElementalStates.h
@@ -1,18 +1,29 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
 
 #include "RE/Skyrim.h"
 #include "SKSE/SKSE.h"
+
+constexpr std::uint32_t FOURCC(char a, char b, char c, char d) noexcept {
+    return (std::uint32_t(a) << 24) | (std::uint32_t(b) << 16) | (std::uint32_t(c) << 8) | std::uint32_t(d);
+}
 
 namespace ElementalStates {
     enum class Flag : std::uint8_t { Wet = 0, Rubber = 1, Fur = 2, Fat = 3 };
 
     void RegisterSerialization();
 
-    void Set(RE::Actor* a, Flag f, bool value);
-    bool Get(RE::Actor* a, Flag f);
-
-    void Clear(RE::Actor* a);
+    void Set(const RE::Actor* a, Flag f, bool value);
+    bool Get(const RE::Actor* a, Flag f);
+    void Clear(const RE::Actor* a);
     void ClearAll();
+}
+
+namespace ElementalStatesTest {
+    void RunOnce();
 }

--- a/src/RemoveDrains.cpp
+++ b/src/RemoveDrains.cpp
@@ -1,0 +1,20 @@
+#include "RemoveDrains.h"
+
+namespace RemoveDrains {
+    void RemoveDrainFromShockAndFrost() {
+        using enum RE::ActorValue;
+        std::vector<std::pair<RE::FormID, RE::ActorValue>> effectIDs = {
+            {0x00013CAB, kMagicka}, {0x000E4CB6, kMagicka}, {0x0010CBDF, kMagicka}, {0x0001CEA8, kMagicka},
+            {0x0010F7EF, kMagicka}, {0x0005DBAE, kMagicka}, {0x0004EFDE, kMagicka}, {0x000D22FA, kMagicka},
+            {0x000EA65A, kStamina}, {0x00013CAA, kStamina}, {0x0010CBDE, kStamina}, {0x0001CEA2, kStamina},
+            {0x0010F7F0, kStamina}, {0x0001CEA3, kStamina}, {0x000EA076, kStamina}, {0x0007E8E2, kStamina},
+            {0x00066335, kStamina}, {0x00066334, kStamina}};
+
+        for (const auto& [formID, expectedAV] : effectIDs) {
+            auto* effect = RE::TESForm::LookupByID<RE::EffectSetting>(formID);
+            if (effect && effect->data.secondaryAV == expectedAV) {
+                effect->data.secondaryAV = kNone;
+            }
+        }
+    }
+}

--- a/src/RemoveDrains.h
+++ b/src/RemoveDrains.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "RE/Skyrim.h"
+#include "SKSE/SKSE.h"
+
+namespace RemoveDrains {
+    void RemoveDrainFromShockAndFrost();
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,4 +1,5 @@
 #include "PCH.h"
+#include "RemoveDrains.h"
 
 #ifndef DLLEXPORT
     #include "REL/Relocation.h"
@@ -11,35 +12,6 @@ using namespace SKSE;
 using namespace RE;
 
 namespace {
-    void RemoveDrainFromShockAndFrost() {
-        std::vector<std::pair<RE::FormID, RE::ActorValue>> effectIDs = {
-            {0x00013CAB, RE::ActorValue::kMagicka}, {0x000E4CB6, RE::ActorValue::kMagicka},
-            {0x0010CBDF, RE::ActorValue::kMagicka}, {0x0001CEA8, RE::ActorValue::kMagicka},
-            {0x0010F7EF, RE::ActorValue::kMagicka}, {0x0005DBAE, RE::ActorValue::kMagicka},
-            {0x0004EFDE, RE::ActorValue::kMagicka}, {0x000D22FA, RE::ActorValue::kMagicka},
-            {0x000EA65A, RE::ActorValue::kStamina}, {0x00013CAA, RE::ActorValue::kStamina},
-            {0x0010CBDE, RE::ActorValue::kStamina}, {0x0001CEA2, RE::ActorValue::kStamina},
-            {0x0010F7F0, RE::ActorValue::kStamina}, {0x0001CEA3, RE::ActorValue::kStamina},
-            {0x000EA076, RE::ActorValue::kStamina}, {0x0007E8E2, RE::ActorValue::kStamina},
-            {0x00066335, RE::ActorValue::kStamina}, {0x00066334, RE::ActorValue::kStamina}};
-
-        for (auto& [formID, expectedAV] : effectIDs) {
-            auto* effect = RE::TESForm::LookupByID<RE::EffectSetting>(formID);
-            if (effect) {
-                if (effect->data.secondaryAV == expectedAV) {
-                    spdlog::info("Removendo {} de '{}'", expectedAV == RE::ActorValue::kMagicka ? "Magicka" : "Stamina",
-                                 effect->GetFormEditorID());
-                    effect->data.secondaryAV = RE::ActorValue::kNone;
-                } else {
-                    spdlog::info("Efeito '{}' já não usa {} como secondaryAV", effect->GetFormEditorID(),
-                                 expectedAV == RE::ActorValue::kMagicka ? "Magicka" : "Stamina");
-                }
-            } else {
-                spdlog::warn("Não foi possível encontrar EffectSetting com FormID {:08X}", formID);
-            }
-        }
-    }
-
     void InitializeLogger() {
         if (auto path = log::log_directory()) {
             *path /= "SMSODestruction.log";
@@ -57,7 +29,7 @@ namespace {
 
         if (msg->type == SKSE::MessagingInterface::kDataLoaded) {
             spdlog::info("kDataLoaded recebido. Iniciando remoção de efeitos.");
-            RemoveDrainFromShockAndFrost();
+            RemoveDrains::RemoveDrainFromShockAndFrost();
         }
     }
 }

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,3 +1,4 @@
+#include "ElementalStates.h"
 #include "PCH.h"
 #include "RemoveDrains.h"
 
@@ -30,6 +31,8 @@ namespace {
         if (msg->type == SKSE::MessagingInterface::kDataLoaded) {
             spdlog::info("kDataLoaded recebido. Iniciando remoção de efeitos.");
             RemoveDrains::RemoveDrainFromShockAndFrost();
+            spdlog::info("Adicionados as flas de estados elementais.");
+            ElementalStates::RegisterSerialization();
         }
     }
 }


### PR DESCRIPTION
Feito a API para gerenciar os estados elementais.
Métodos de get e set estados elementais dos atores. 
Os estados elementais são gerenciados de forma própria e serializados com SKSE OnSave.