### PR TITLE
feat(FullElementEffect): :sparkles: Trigger para ativar os efeitos qu…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/common/PluginSerialization.cpp
     src/ElementalGauges.cpp
     src/ElementalGaugesHook.cpp
+    src/ElementalEffects.cpp
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
@@ -33,6 +34,7 @@ target_precompile_headers(
   src/common/Helpers.h
   src/ElementalGauges.h
   src/ElementalGaugesHook.h
+  src/ElementalEffects.h
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "SMSODestruction")

--- a/src/ElementalEffects.cpp
+++ b/src/ElementalEffects.cpp
@@ -1,0 +1,27 @@
+#include "ElementalEffects.h"
+
+namespace ElementalEffects {
+    static void EfeitoFogo(RE::Actor* a, ElementalGauges::Type, void*) { spdlog::info("reacao de fogo ativada"); }
+    static void EfeitoGelo(RE::Actor* a, ElementalGauges::Type, void*) { spdlog::info("reacao de gelo ativada"); }
+    static void EfeitoShock(RE::Actor* a, ElementalGauges::Type, void*) { spdlog::info("reacao de shock ativada"); }
+
+    void ConfigurarGatilhos() {
+        using Type = ElementalGauges::Type;
+
+        ElementalGauges::FullTrigger fire{};
+        fire.cb = &EfeitoFogo;
+        fire.lockoutSeconds = 10.0f;
+        fire.lockoutIsRealTime = false;
+        fire.clearOnTrigger = true;
+        fire.deferToTask = true;
+
+        ElementalGauges::FullTrigger frost = fire;
+        frost.cb = &EfeitoGelo;
+        ElementalGauges::FullTrigger shock = fire;
+        shock.cb = &EfeitoShock;
+
+        ElementalGauges::SetOnFull(Type::Fire, fire);
+        ElementalGauges::SetOnFull(Type::Frost, frost);
+        ElementalGauges::SetOnFull(Type::Shock, shock);
+    }
+}

--- a/src/ElementalEffects.h
+++ b/src/ElementalEffects.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ElementalGauges.h"
+#include "RE/Skyrim.h"
+#include "SKSE/SKSE.h"
+
+namespace ElementalEffects {
+    void ConfigurarGatilhos();
+}

--- a/src/ElementalGauges.h
+++ b/src/ElementalGauges.h
@@ -8,12 +8,27 @@
 namespace ElementalGauges {
     enum class Type : std::uint8_t { Fire = 0, Frost = 1, Shock = 2 };
 
+    struct FullTrigger {
+        using Callback = void (*)(RE::Actor* actor, Type t, void* user);
+
+        Callback cb{nullptr};
+        void* user{nullptr};
+
+        float lockoutSeconds{0.0f};
+        bool lockoutIsRealTime{false};
+
+        bool clearOnTrigger{true};
+        bool deferToTask{true};
+    };
+
+    void SetOnFull(Type t, const FullTrigger& cfg);
+
     void RegisterStore();
 
-    std::uint8_t Get(const RE::Actor* a, Type t);
-    void Set(const RE::Actor* a, Type t, std::uint8_t value);  // clamp 0..100
-    void Add(const RE::Actor* a, Type t, int delta);           // saturating add
-    void Clear(const RE::Actor* a);
+    std::uint8_t Get(RE::Actor* a, Type t);
+    void Set(RE::Actor* a, Type t, std::uint8_t value);
+    void Add(RE::Actor* a, Type t, int delta);
+    void Clear(RE::Actor* a);
     void ClearAll();
 }
 

--- a/src/ElementalGaugesHook.h
+++ b/src/ElementalGaugesHook.h
@@ -5,5 +5,5 @@
 
 namespace ElementalGaugesHook {
     void Install();
-    void RegisterAEEventSink();  // chame uma vez após DataLoaded
+    void RegisterAEEventSink();
 }

--- a/src/ElementalStates.cpp
+++ b/src/ElementalStates.cpp
@@ -25,7 +25,7 @@ namespace ElementalStates {
         inline constexpr std::uint32_t kVersion = 1;
     }
 
-    void Set(const RE::Actor* a, Flag f, bool value) {
+    void Set(RE::Actor* a, Flag f, bool value) {
         if (!a) return;
         auto& b = Flags::state()[a->GetFormID()];
         const auto m = Flags::bit(f);
@@ -34,13 +34,13 @@ namespace ElementalStates {
         else
             b &= ~m;
     }
-    bool Get(const RE::Actor* a, Flag f) {
+    bool Get(RE::Actor* a, Flag f) {
         if (!a) return false;
         const auto it = Flags::state().find(a->GetFormID());
         if (it == Flags::state().end()) return false;
         return (it->second & Flags::bit(f)) != std::byte{0};
     }
-    void Clear(const RE::Actor* a) {
+    void Clear(RE::Actor* a) {
         if (a) Flags::state().erase(a->GetFormID());
     }
     void ClearAll() { Flags::state().clear(); }

--- a/src/ElementalStates.h
+++ b/src/ElementalStates.h
@@ -4,12 +4,12 @@
 #include "SKSE/SKSE.h"
 
 namespace ElementalStates {
-    enum class Flag : std::uint8_t { Wet = 0, Rubber = 1, Fur = 2, Fat = 3 };
+    enum class Flag : std::uint8_t { Wet = 0, Rubber = 1, Fur = 2 };
 
     void RegisterStore();
 
-    void Set(const RE::Actor* a, Flag f, bool value);
-    bool Get(const RE::Actor* a, Flag f);
-    void Clear(const RE::Actor* a);
+    void Set(RE::Actor* a, Flag f, bool value);
+    bool Get(RE::Actor* a, Flag f);
+    void Clear(RE::Actor* a);
     void ClearAll();
 }

--- a/src/common/Helpers.h
+++ b/src/common/Helpers.h
@@ -1,28 +1,23 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
-constexpr std::uint32_t FOURCC(char a, char b, char c, char d) noexcept {
+[[nodiscard]] consteval std::uint32_t FOURCC(char a, char b, char c, char d) {
     return (std::uint32_t(a) << 24) | (std::uint32_t(b) << 16) | (std::uint32_t(c) << 8) | std::uint32_t(d);
 }
 
-constexpr std::uint8_t clamp100(int v) noexcept {
-    int result;
-    if (v < 0) {
-        result = 0;
-    } else if (v > 100) {
-        result = 100;
-    } else {
-        result = v;
-    }
-    return static_cast<std::uint8_t>(result);
+[[nodiscard]] constexpr std::uint8_t clamp100(int v) noexcept {
+    return static_cast<std::uint8_t>(std::clamp(v, 0, 100));
 }
 
-static RE::Actor* ResolveTarget(RE::ActiveEffect* ae, RE::MagicTarget* mt) {
+inline RE::Actor* ResolveTarget(RE::ActiveEffect* ae, RE::MagicTarget* mt) noexcept {
     if constexpr (requires(RE::ActiveEffect* x) { x->GetTargetActor(); }) {
-        if (auto* a = ae->GetTargetActor()) return a;
+        if (ae) {
+            if (auto* a = ae->GetTargetActor()) return a;
+        }
     }
     if (mt) {
         if (auto* ref = skyrim_cast<RE::TESObjectREFR*>(mt)) {
@@ -32,17 +27,14 @@ static RE::Actor* ResolveTarget(RE::ActiveEffect* ae, RE::MagicTarget* mt) {
     return nullptr;
 }
 
-static RE::Actor* AsActor(RE::MagicTarget* mt) {
+inline RE::Actor* AsActor(RE::MagicTarget* mt) noexcept {
     if (!mt) return nullptr;
-
-    // NG fornece skyrim_cast<> para atravessar herança múltipla com RTTI
-    if (auto a = skyrim_cast<RE::Actor*>(mt)) return a;
-
-    // fallback caso você esteja sem skyrim_cast por algum motivo
+    if (auto* ref = skyrim_cast<RE::TESObjectREFR*>(mt))
+        if (auto* a = ref->As<RE::Actor>()) return a;
     return dynamic_cast<RE::Actor*>(mt);
 }
 
-static float GetHealth(RE::Actor* a) {
+[[nodiscard]] inline float GetHealth(RE::Actor* a) noexcept {
     if (!a) return 0.0f;
     if (auto avo = skyrim_cast<RE::ActorValueOwner*>(a)) {
         return avo->GetActorValue(RE::ActorValue::kHealth);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -1,3 +1,4 @@
+#include "ElementalEffects.h"
 #include "ElementalGauges.h"
 #include "ElementalGaugesHook.h"
 #include "ElementalStates.h"
@@ -38,7 +39,9 @@ namespace {
                 RemoveDrains::RemoveDrainFromShockAndFrost();
                 ElementalGaugesHook::Install();
                 ElementalGaugesHook::RegisterAEEventSink();
-                spdlog::info("listener de magias instalado.");
+                spdlog::info("Hook para gauges instalado.");
+                ElementalEffects::ConfigurarGatilhos();
+                spdlog::info("Efeitos registrados.");
                 break;
             case SKSE::MessagingInterface::kNewGame:
                 [[fallthrough]];


### PR DESCRIPTION
…ando o gauge chegar a 100

Adicionei os trigger para ativar os efeitos de quando cada gauge elemental chega a 100. O gauge então é resatado para 0 e não é possível acumular por X segundos. Os efeitos foram colocados no arquivo ElementalEffects. Foram removidos comentários e feita algumas refatorações em arquivos como Helpers e ElementalStates.

Updates #4

## Summary by Sourcery

Enable a trigger system for elemental gauges reaching 100 that clears the gauge, enforces lockout, and dispatches configured callbacks (deferred or immediate), plus introduce default elemental reactions and refactor related helper and state code.

New Features:
- Add FullTrigger struct and SetOnFull API to configure callbacks when an elemental gauge reaches full
- Implement trigger logic in ElementalGauges with automatic gauge clearing, lockout periods, and deferred task dispatch
- Introduce ElementalEffects module with default Fire, Frost, and Shock reactions configured on gauge full

Enhancements:
- Refactor Helpers.h to use std::clamp in clamp100 and make FOURCC a consteval function
- Remove 'Fat' flag from ElementalStates and standardize API to use RE::Actor* instead of const pointers
- Clean up ElementalGaugesHook and serialization code, remove outdated comments, and adjust gauge multipliers

Build:
- Update CMakeLists to include ElementalEffects.cpp and its header in the build